### PR TITLE
docker: fix build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ FROM ubuntu:latest
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
-    python3 python3-pip curl wget git wkhtmltopdf libssl1.0-dev vim nmap tzdata
+    python3 python3-pip curl wget git wkhtmltopdf libssl-dev vim nmap tzdata
 
 RUN mkdir /opt/xml && mkdir /opt/notes && \
     wget -P /opt/ https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz && \


### PR DESCRIPTION
fix this error:

```
$ docker build .   
Sending build context to Docker daemon  13.82kB
Step 1/14 : FROM ubuntu:latest
latest: Pulling from library/ubuntu
4d32b49e2995: Pull complete 
Digest: sha256:bea6d19168bbfd6af8d77c2cc3c572114eb5d113e6f422573c93cb605a0e2ffb
Status: Downloaded newer image for ubuntu:latest
 ---> ff0fea8310f3
Step 2/14 : ENV DEBIAN_FRONTEND noninteractive
 ---> Running in ae7eb46c3520
Removing intermediate container ae7eb46c3520
 ---> 0d4b26a67e21
Step 3/14 : RUN apt-get update && apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages     python3 python3-pip curl wget git wkhtmltopdf libssl1.0-dev vim nmap tzdata
 ---> Running in 93e080a3a34c
Get:1 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
Get:2 http://archive.ubuntu.com/ubuntu focal InRelease [265 kB]
Get:3 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [1646 kB]
Get:4 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [1027 kB]
Get:5 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
Get:6 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [25.8 kB]
Get:7 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [859 kB]
Get:8 http://archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
Get:9 http://archive.ubuntu.com/ubuntu focal/main amd64 Packages [1275 kB]
Get:10 http://archive.ubuntu.com/ubuntu focal/universe amd64 Packages [11.3 MB]
Get:11 http://archive.ubuntu.com/ubuntu focal/multiverse amd64 Packages [177 kB]
Get:12 http://archive.ubuntu.com/ubuntu focal/restricted amd64 Packages [33.4 kB]
Get:13 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [1142 kB]
Get:14 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [2060 kB]
Get:15 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [29.4 kB]
Get:16 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [1096 kB]
Get:17 http://archive.ubuntu.com/ubuntu focal-backports/main amd64 Packages [51.2 kB]
Get:18 http://archive.ubuntu.com/ubuntu focal-backports/universe amd64 Packages [26.0 kB]
Fetched 21.4 MB in 6s (3798 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Package libssl1.0-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'libssl1.0-dev' has no installation candidate
The command '/bin/sh -c apt-get update && apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages     python3 python3-pip curl wget git wkhtmltopdf libssl1.0-dev vim nmap tzdata' returned a non-zero code: 100
```

ubuntu:latest docker image tag now points to ubuntu focal

https://packages.ubuntu.com/search?keywords=libssl&searchon=names&suite=focal&section=all